### PR TITLE
Fix white bar on the left of html2canvas by hiding the scrollbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -52,6 +52,11 @@
   outline: none !important;
 }
 
+.hide-scrollbar {
+  overflow: -moz-hidden-unscrollable;
+  overflow: hidden;
+}
+
 .AppBody {
   text-align: center;
   position: relative;

--- a/src/Screenshot.js
+++ b/src/Screenshot.js
@@ -4,8 +4,10 @@ import html2canvas from 'html2canvas';
 function Screenshot() {
   const [shouldDraw, setShouldDraw] = useState(true);
   useEffect(() => {
+    document.body.classList.add('hide-scrollbar');
     html2canvas(document.querySelector('.AppBody')).then(canvas => {
       document.querySelector('.AppBody').replaceWith(canvas);
+      document.body.classList.remove('hide-scrollbar');
     });
 
     setShouldDraw(false);


### PR DESCRIPTION
## Problem
While running the infographic generator on Windows, a white bar was showing up on the resulting canvas. [This issue](https://github.com/niklasvh/html2canvas/issues/1438#issuecomment-366727801) suggested it was because of the scrollbar, which appears to be correct.

<kbd>
  <img src="https://cdn.discordapp.com/attachments/335575319597547521/643992738374746132/file-name_29.png">
</kbd>

## Solution
Temporarily hide the scrollbar while we generate the canvas. Reveal it once the canvas is generated.

<kbd>
  <img src="https://user-images.githubusercontent.com/23489172/74581790-d499c480-4f70-11ea-8246-18823eda8f96.png">
</kbd>